### PR TITLE
change base image and install aws cli 2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,20 @@
-FROM alpine AS builder
-RUN apk add --update --no-cache \
-    python3 \
-    python3-dev \
-    py3-pip \
-    build-base \
-  && pip3 install --prefix=/install \
-    awscli \
-    boto3
+FROM cimg/python:3.7 AS base
 
-FROM hashicorp/packer:latest AS runner
+FROM base AS builder
+ENV PACKER_VERSION "1.6.4"
+
+WORKDIR /tmp
+RUN curl "https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip" -o "packer.zip" \
+    && unzip packer.zip \
+    && sudo cp packer /usr/local/bin \
+    && packer --version
+
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
+    && unzip awscliv2.zip \
+    && sudo ./aws/install \
+    && aws --version
+
+FROM base AS runner
 LABEL maintainer="Brett Taylor <github.com/ssplatt>"
-COPY --from=builder /install /usr/local
-RUN apk add --update --no-cache \
-    python3 \
-    python3-dev \
-    py3-pip \
-    build-base \
-    libffi-dev \
-    openssl-dev \
-    git \
-    jq \
-    openssh \
-    bash \
-    curl 
-
+COPY --from=builder /usr/local /usr/local
 ENTRYPOINT ["/bin/bash"]


### PR DESCRIPTION
aws cli didn't like alpine linux, so change to a `cimg` which uses `debian` as base